### PR TITLE
fixed cleanup of container images

### DIFF
--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -62,3 +62,12 @@
        command:  "ip link delete tap-c-{{ item.0 }} type bridge"  
        become: yes
        with_sequence: "start=0 count={{ numberOfClientNodes }}"
+
+ # REMOVE Container images
+     - name: remove client image
+       command: "docker image rm {{ baseContainerName }}_client:latest"
+       ignore_errors: yes
+
+     - name: remove server image
+       command: "docker image rm {{ baseContainerName }}_server:latest"
+       ignore_errors: yes


### PR DESCRIPTION
Bugfix: Remove container images in the cleanup script. If an image already exists, no new container image is used, and instead, the old container images are taken. Therefore, the container images are removed in the cleanup process.